### PR TITLE
Swift update & Breaking Crashlytics

### DIFF
--- a/DummyViewController.swift
+++ b/DummyViewController.swift
@@ -23,7 +23,7 @@ class DummyViewController: UIViewController {
         self.frame = withFrame
     }
 
-    required init(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
     

--- a/HackCWRU App/AppDelegate.swift
+++ b/HackCWRU App/AppDelegate.swift
@@ -53,7 +53,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     lazy var applicationDocumentsDirectory: NSURL = {
         // The directory the application uses to store the Core Data store file. This code uses a directory named "cwruhacsoc.HackCWRU_App" in the application's documents Application Support directory.
         let urls = NSFileManager.defaultManager().URLsForDirectory(.DocumentDirectory, inDomains: .UserDomainMask)
-        return urls[urls.count-1] as! NSURL
+        return urls[urls.count-1] as NSURL
     }()
 
     lazy var managedObjectModel: NSManagedObjectModel = {
@@ -62,37 +62,35 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return NSManagedObjectModel(contentsOfURL: modelURL)!
     }()
 
-    lazy var persistentStoreCoordinator: NSPersistentStoreCoordinator? = {
-        // The persistent store coordinator for the application. This implementation creates and return a coordinator, having added the store for the application to it. This property is optional since there are legitimate error conditions that could cause the creation of the store to fail.
+    lazy var persistentStoreCoordinator: NSPersistentStoreCoordinator = {
+        // The persistent store coordinator for the application. This implementation creates and returns a coordinator, having added the store for the application to it. This property is optional since there are legitimate error conditions that could cause the creation of the store to fail.
         // Create the coordinator and store
-        var coordinator: NSPersistentStoreCoordinator? = NSPersistentStoreCoordinator(managedObjectModel: self.managedObjectModel)
-        let url = self.applicationDocumentsDirectory.URLByAppendingPathComponent("HackCWRU_App.sqlite")
-        var error: NSError? = nil
+        let coordinator = NSPersistentStoreCoordinator(managedObjectModel: self.managedObjectModel)
+        let url = self.applicationDocumentsDirectory.URLByAppendingPathComponent("SingleViewCoreData.sqlite")
         var failureReason = "There was an error creating or loading the application's saved data."
-        if coordinator!.addPersistentStoreWithType(NSSQLiteStoreType, configuration: nil, URL: url, options: nil, error: &error) == nil {
-            coordinator = nil
+        do {
+            try coordinator.addPersistentStoreWithType(NSSQLiteStoreType, configuration: nil, URL: url, options: nil)
+        } catch {
             // Report any error we got.
             var dict = [String: AnyObject]()
             dict[NSLocalizedDescriptionKey] = "Failed to initialize the application's saved data"
             dict[NSLocalizedFailureReasonErrorKey] = failureReason
-            dict[NSUnderlyingErrorKey] = error
-            error = NSError(domain: "YOUR_ERROR_DOMAIN", code: 9999, userInfo: dict)
+            
+            dict[NSUnderlyingErrorKey] = error as NSError
+            let wrappedError = NSError(domain: "YOUR_ERROR_DOMAIN", code: 9999, userInfo: dict)
             // Replace this with code to handle the error appropriately.
             // abort() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-            NSLog("Unresolved error \(error), \(error!.userInfo)")
+            NSLog("Unresolved error \(wrappedError), \(wrappedError.userInfo)")
             abort()
         }
         
         return coordinator
     }()
 
-    lazy var managedObjectContext: NSManagedObjectContext? = {
+    lazy var managedObjectContext: NSManagedObjectContext = {
         // Returns the managed object context for the application (which is already bound to the persistent store coordinator for the application.) This property is optional since there are legitimate error conditions that could cause the creation of the context to fail.
         let coordinator = self.persistentStoreCoordinator
-        if coordinator == nil {
-            return nil
-        }
-        var managedObjectContext = NSManagedObjectContext()
+        var managedObjectContext = NSManagedObjectContext(concurrencyType: .MainQueueConcurrencyType)
         managedObjectContext.persistentStoreCoordinator = coordinator
         return managedObjectContext
     }()
@@ -100,12 +98,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: - Core Data Saving support
 
     func saveContext () {
-        if let moc = self.managedObjectContext {
-            var error: NSError? = nil
-            if moc.hasChanges && !moc.save(&error) {
+        if managedObjectContext.hasChanges {
+            do {
+                try managedObjectContext.save()
+            } catch {
                 // Replace this implementation with code to handle the error appropriately.
                 // abort() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                NSLog("Unresolved error \(error), \(error!.userInfo)")
+                let nserror = error as NSError
+                NSLog("Unresolved error \(nserror), \(nserror.userInfo)")
                 abort()
             }
         }

--- a/HackCWRU App/AttendeeInformationController.swift
+++ b/HackCWRU App/AttendeeInformationController.swift
@@ -18,7 +18,7 @@ class AttendeeInformationController: UIPageViewController, UIPageViewControllerD
     var frame:CGRect?
     
     //Custom initializer to send in a frame yay
-    init(transitionStyle style: UIPageViewControllerTransitionStyle, navigationOrientation: UIPageViewControllerNavigationOrientation, options: [NSObject : AnyObject]?, frame:CGRect) {
+    init(transitionStyle style: UIPageViewControllerTransitionStyle, navigationOrientation: UIPageViewControllerNavigationOrientation, options: [String : AnyObject]?, frame:CGRect) {
         
         super.init(transitionStyle: style, navigationOrientation: navigationOrientation, options: options)
         
@@ -31,7 +31,7 @@ class AttendeeInformationController: UIPageViewController, UIPageViewControllerD
 
     //Required by Swift. Why? Because.
     required init(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
+        super.init(coder: aDecoder)!
     }
     
     override func viewWillAppear(animated: Bool) {
@@ -47,7 +47,7 @@ class AttendeeInformationController: UIPageViewController, UIPageViewControllerD
         //If we aren't presented, we can drop our controllers for now
         if self.isViewLoaded() && self.view.window == nil {
             self.controllers = [UIPageViewController]()
-            println("Doing a memory dump in AttendeeInformationController. Good fucking job.")
+            print("Doing a memory dump in AttendeeInformationController. Good fucking job.")
         }
     }
     

--- a/HackCWRU App/UserTabBarController.swift
+++ b/HackCWRU App/UserTabBarController.swift
@@ -39,7 +39,7 @@ class UserTabBarController: UITabBarController {
         //If we aren't presented, we can drop our controllers for now
         if self.isViewLoaded() && self.view.window == nil {
             self.viewControllers = [UIViewController]()
-            println("Doing a memory dump in UserTabBarController. How the fuck did you manage that?")
+            print("Doing a memory dump in UserTabBarController. How the fuck did you manage that?")
         }
     }
     

--- a/HackCWRU.xcodeproj/project.pbxproj
+++ b/HackCWRU.xcodeproj/project.pbxproj
@@ -38,7 +38,7 @@
 		9B70BBB51B0D813B0008F959 /* Crashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Crashlytics.framework; sourceTree = "<group>"; };
 		9B70BBBB1B105BE00008F959 /* settings.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = settings.png; sourceTree = "<group>"; };
 		9B70BBBF1B114DAC0008F959 /* DummyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DummyViewController.swift; path = ../DummyViewController.swift; sourceTree = "<group>"; };
-		9BEB568F1B0C411F0001EC73 /* HackCWRU App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "HackCWRU App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9BEB568F1B0C411F0001EC73 /* HackCWRU.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HackCWRU.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9BEB56931B0C411F0001EC73 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9BEB56941B0C411F0001EC73 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9BEB56971B0C411F0001EC73 /* HackCWRU_App.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = HackCWRU_App.xcdatamodel; sourceTree = "<group>"; };
@@ -83,7 +83,7 @@
 		9BEB56901B0C411F0001EC73 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				9BEB568F1B0C411F0001EC73 /* HackCWRU App.app */,
+				9BEB568F1B0C411F0001EC73 /* HackCWRU.app */,
 				9BEB56A71B0C411F0001EC73 /* HackCWRUTests.xctest */,
 			);
 			name = Products;
@@ -151,7 +151,7 @@
 			);
 			name = HackCWRU;
 			productName = "HackCWRU App";
-			productReference = 9BEB568F1B0C411F0001EC73 /* HackCWRU App.app */;
+			productReference = 9BEB568F1B0C411F0001EC73 /* HackCWRU.app */;
 			productType = "com.apple.product-type.application";
 		};
 		9BEB56A61B0C411F0001EC73 /* HackCWRUTests */ = {

--- a/HackCWRU.xcodeproj/project.pbxproj
+++ b/HackCWRU.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		49FEF73D1B1274FB005B55E2 /* AttendeeInformationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FEF73C1B1274FB005B55E2 /* AttendeeInformationController.swift */; };
 		49FEF73E1B1274FB005B55E2 /* AttendeeInformationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FEF73C1B1274FB005B55E2 /* AttendeeInformationController.swift */; };
-		9B70BBB61B0D813B0008F959 /* Crashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B70BBB51B0D813B0008F959 /* Crashlytics.framework */; };
 		9B70BBBC1B105BE00008F959 /* settings.png in Resources */ = {isa = PBXBuildFile; fileRef = 9B70BBBB1B105BE00008F959 /* settings.png */; };
 		9B70BBC01B114DAC0008F959 /* DummyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B70BBBF1B114DAC0008F959 /* DummyViewController.swift */; };
 		9B70BBC11B118E2E0008F959 /* UserTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BEB56991B0C411F0001EC73 /* UserTabBarController.swift */; };
@@ -35,7 +34,6 @@
 
 /* Begin PBXFileReference section */
 		49FEF73C1B1274FB005B55E2 /* AttendeeInformationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttendeeInformationController.swift; sourceTree = "<group>"; };
-		9B70BBB51B0D813B0008F959 /* Crashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Crashlytics.framework; sourceTree = "<group>"; };
 		9B70BBBB1B105BE00008F959 /* settings.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = settings.png; sourceTree = "<group>"; };
 		9B70BBBF1B114DAC0008F959 /* DummyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DummyViewController.swift; path = ../DummyViewController.swift; sourceTree = "<group>"; };
 		9BEB568F1B0C411F0001EC73 /* HackCWRU.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HackCWRU.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -56,7 +54,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9B70BBB61B0D813B0008F959 /* Crashlytics.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -76,7 +73,6 @@
 				9BEB56911B0C411F0001EC73 /* HackCWRU */,
 				9BEB56AA1B0C411F0001EC73 /* HackCWRUTests */,
 				9BEB56901B0C411F0001EC73 /* Products */,
-				9B70BBB51B0D813B0008F959 /* Crashlytics.framework */,
 			);
 			sourceTree = "<group>";
 		};
@@ -243,7 +239,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "./Crashlytics.framework/run 479c2e2984369c33402ef64007433deaa5acebe9 e8afa25dddc84c086b08a738f50370285c70d184f08f51c0b705a0e5885aef66";
+			shellScript = "";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Updated to the newest Swift standard and got rid of Crashlytics because we definitely don't need that mucking things up right now. If you need more explanation than the title, I'm a little concerned.
